### PR TITLE
Migrate to Niri WM (Catppuccin Mocha) + RU/US layouts + Fuzzel on Mod+Space

### DIFF
--- a/todo/01.sh
+++ b/todo/01.sh
@@ -1,3 +1,17 @@
 #! /bin/bash
-cp sxbox/user/xinitrc ~/.xinitrc
-cp sxbox/user/Xresources ~/.Xresources
+set -euo pipefail
+
+# Create config directories
+mkdir -p ~/.config/niri
+mkdir -p ~/.config/fuzzel
+
+# Copy Niri and Fuzzel configs from repo
+cp -f sxbox/user/.config/niri/config.kdl ~/.config/niri/config.kdl
+cp -f sxbox/user/.config/fuzzel/fuzzel.ini ~/.config/fuzzel/fuzzel.ini
+
+# Optional: set default locale to Russian with UTF-8 (requires root)
+echo "[i] To enable Russian system locale, as root do:"
+echo "    sed -i 's/^#\s*ru_RU.UTF-8/ru_RU.UTF-8/' /etc/locale.gen && locale-gen"
+echo "    echo 'LANG=ru_RU.UTF-8' > /etc/locale.conf"
+
+echo "[i] Done. Start a Niri session from the login manager or run 'niri --session' from a TTY."

--- a/user/.config/fuzzel/fuzzel.ini
+++ b/user/.config/fuzzel/fuzzel.ini
@@ -1,0 +1,21 @@
+# Fuzzel configuration - Catppuccin Mocha
+# Place in ~/.config/fuzzel/fuzzel.ini
+
+[main]
+font = JetBrains Mono:size=12
+terminal = alacritty -e
+icon-theme = Papirus-Dark
+icons-enabled = yes
+# dpi-aware sizes are handled by the compositor
+
+[colors]
+# RGBA hex values
+background = 1e1e2eff  # base
+text = cdd6f4ff        # text
+match = f9e2afff       # yellow
+selection = 313244ff   # surface0
+selection-text = cdd6f4ff
+border = 585b70ff      # surface2
+
+[border]
+width = 2

--- a/user/.config/niri/config.kdl
+++ b/user/.config/niri/config.kdl
@@ -1,0 +1,66 @@
+# Niri configuration - Catppuccin Mocha + RU/US + Fuzzel on Mod+Space
+
+# Input configuration: Mod key and keyboard layouts
+input {
+    # Place Mod to the left of Space depends on hardware; here we set logical Mod
+    # Mod will be Super on TTY and Alt when nested by default. We can force it:
+    mod-key "Super"
+    mod-key-nested "Alt"
+
+    keyboard {
+        # XKB setup: US first (latin for binds), RU second
+        xkb {
+            layout "us,ru"
+            variant ""
+            # Switch layout by Mod+Space (Windows/Super + Space)
+            options "grp:win_space_toggle"
+        }
+        # Tuning
+        repeat-delay 600
+        repeat-rate 25
+    }
+}
+
+# Bindings: Fuzzel on Mod+Space, common essentials
+binds {
+    # Launcher on Mod + Space
+    Mod+Space { spawn "fuzzel"; }
+
+    # Terminal on Mod + Enter (adjust to your terminal)
+    Mod+Return { spawn "alacritty"; }
+
+    # Exit Niri
+    Mod+Shift+E { action "quit"; }
+}
+
+# Layout and appearance tuned to Catppuccin Mocha palette
+# https://catppuccin.com/palette#mocha
+layout {
+    gaps 12
+
+    # Workspace background (base)
+    background-color "#1e1e2e"
+
+    # Window border
+    border {
+        width 2
+        active-color "#89b4fa"   # Blue
+        inactive-color "#585b70" # Surface2
+        urgent-color "#f38ba8"   # Red
+        # Example gradient (disabled):
+        # active-gradient from="#89b4fa" to="#b4befe" angle=90 in="oklch longer hue"
+    }
+
+    # Focus ring for active window
+    focus-ring {
+        width 4
+        active-color "#cba6f7"   # Mauve
+        inactive-color "#45475a" # Surface1
+        urgent-color "#f38ba8"
+    }
+
+    # Tab indicator styling (if using tabs)
+    tab-indicator {
+        corner-radius 8
+    }
+}


### PR DESCRIPTION
This PR migrates the project from Openbox to Niri with Catppuccin Mocha look-and-feel, sets up RU/US XKB layouts with Win+Space toggle, and binds Fuzzel to Mod+Space.\n\nChanges:\n- Add ~/.config/niri/config.kdl with Catppuccin Mocha colors (border/focus-ring), RU/US layouts, Mod+Space for fuzzel, Mod+Return terminal.\n- Add ~/.config/fuzzel/fuzzel.ini themed with Catppuccin Mocha.\n- Update todo/01.sh to install these configs for the user.\n\nUsage:\n- pacman -S niri fuzzel alacritty\n- Run the bootstrap: chmod +x todo/01.sh && ./todo/01.sh\n- Start niri session: niri --session or from a display manager.\n\nNotes:\n- System RU locale can be enabled via /etc/locale.gen and /etc/locale.conf as shown in the script hints.\n- Mod defaults to Super on TTY; nested sessions use Alt.\n